### PR TITLE
fix: use base64url to encode session-id

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,15 @@ module.exports = generateSessionId
 
 var crypto = require('crypto')
 
+var base64url = require('base64url')
+
 function generateSessionId (options) {
   var timestamp = options.timestamp.toString(16).toUpperCase()
   var sessionData = options.username + ':' + timestamp
-  var hmac = crypto.createHmac('sha1', options.salt + options.secret)
-  hmac.update(sessionData)
+  var hmac = crypto.createHmac('sha1', options.salt + options.secret).update(sessionData)
 
-  return Buffer.concat([
+  return base64url(Buffer.concat([
     new Buffer(sessionData + ':'),
     hmac.digest()
-  ]).toString('base64').replace(/\+/g, '-')
+  ]))
 }

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "nyc": "^5.0.0",
     "semantic-release": "^6.0.3",
     "tap": "^2.3.1"
+  },
+  "dependencies": {
+    "base64url": "^1.0.5"
   }
 }


### PR DESCRIPTION
This is closer to the CouchDB implementation, and should cover more edge cases than `.replace(/\+/g, '-')`.
