### PR TITLE
feat: smaller bundle size using crypto-lite in browser

### DIFF
--- a/lib/hmac-browser.js
+++ b/lib/hmac-browser.js
@@ -1,0 +1,3 @@
+module.exports = function (key, message) {
+  return new Buffer(require('crypto-lite').crypto.hmac('sha1', key, message), 'hex');
+}

--- a/lib/hmac.js
+++ b/lib/hmac.js
@@ -1,0 +1,3 @@
+module.exports = function (key, message) {
+  return require('crypto').createHmac('sha1', key).update(message).digest()
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,7 @@
 module.exports = calculateSessionId
 
-var crypto = require('crypto')
-
 var base64url = require('base64url')
+var createHmac = require('./hmac')
 var validate = require('aproba')
 
 function calculateSessionId (username, usersalt, serversecret, timestamp) {
@@ -10,10 +9,10 @@ function calculateSessionId (username, usersalt, serversecret, timestamp) {
 
   var timestamp16 = timestamp.toString(16).toUpperCase()
   var sessionData = username + ':' + timestamp16
-  var hmac = crypto.createHmac('sha1', serversecret + usersalt).update(sessionData)
+  var hmac = createHmac(serversecret + usersalt, sessionData)
 
   return base64url(Buffer.concat([
     new Buffer(sessionData + ':'),
-    hmac.digest()
+    hmac
   ]))
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "couchdb-calculate-session-id",
   "description": "calculates valid CouchDB session IDs using username, salt, secret & timestamp",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "pertest": "standard",
@@ -31,6 +31,10 @@
   },
   "dependencies": {
     "aproba": "^1.0.1",
-    "base64url": "^1.0.5"
+    "base64url": "^1.0.5",
+    "crypto-lite": "^0.1.0"
+  },
+  "browser": {
+    "./lib/hmac.js": "./lib/hmac-browser.js"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 var test = require('tap').test
 
-var calculateSessionId = require('../index')
+var calculateSessionId = require('../')
 
 test('valid arguments CouchDB 1.5', function (t) {
   var expectedSessionId = 'amFuOjU2Njg4MkI5OkEK3-1SRseo6yNRHfk-mmk6zOxm'


### PR DESCRIPTION
The promised PR. I tested it by just temporarily changing './hmac' to './hmac-browser' in `lib/index.js`, followed by the default 'npm test'.
